### PR TITLE
Capture lambda variable context in MessageBoxAltEx and SetGameMainLoo…

### DIFF
--- a/functions_jip/jip_fn_script.h
+++ b/functions_jip/jip_fn_script.h
@@ -155,6 +155,7 @@ bool Cmd_SetGameMainLoopCallback_Execute(COMMAND_ARGS)
 			{
 				callback = MainLoopCallback::Create(script, callingRef, 0, callDelay);
 				callback->isScript = true;
+				callback->lambdaVariableContext = LambdaVariableContext(script);
 				callback->arg.uVal = callingRef->refID;
 			}
 			callback->flags = (modeFlag & 0xB);

--- a/functions_jip/jip_fn_ui.h
+++ b/functions_jip/jip_fn_ui.h
@@ -1079,6 +1079,11 @@ bool Cmd_ShowQuantityMenu_Execute(COMMAND_ARGS)
 	return true;
 }
 
+void ResetMessageBoxLambdaVars()
+{
+	s_messageBoxScriptVariableContext = LambdaVariableContext(nullptr);
+}
+
 __declspec(naked) void MessageBoxCallback()
 {
 	__asm
@@ -1100,6 +1105,7 @@ __declspec(naked) void MessageBoxCallback()
 		push	eax
 		call	CallFunction
 		add		esp, 0x10
+		call	ResetMessageBoxLambdaVars
 	done:
 		retn
 	}
@@ -1141,6 +1147,8 @@ bool Cmd_MessageBoxExAlt_Execute(COMMAND_ARGS)
 	if (!s_messageBoxScript && ExtractFormatStringArgs(1, buffer, EXTRACT_ARGS_EX, kCommandInfo_MessageBoxExAlt.numParams, &callback))
 	{
 		s_messageBoxScript = callback;
+		s_messageBoxScriptVariableContext = LambdaVariableContext(callback);
+		
 		char *msgStrings[0x102], **buttonPtr = msgStrings + 2, *delim = buffer;
 		*buttonPtr = NULL;
 		for (UInt32 count = 0xFF; count; count--)

--- a/internal/hooks.h
+++ b/internal/hooks.h
@@ -300,7 +300,8 @@ struct MainLoopCallback
 		FunctionArg	arg;
 		FunctionArg	*pArgs;
 	};
-
+	LambdaVariableContext lambdaVariableContext;
+	
 	static MainLoopCallback *Create(void *_cmdPtr, void *_thisObj, UInt32 _callCount = 1, UInt32 _callDelay = 1, UInt8 _numArgs = 0);
 
 	void Execute();

--- a/internal/jip_core.cpp
+++ b/internal/jip_core.cpp
@@ -31,6 +31,8 @@ _GetElements GetElements;
 _ExtractArgsEx ExtractArgsEx;
 _ExtractFormatStringArgs ExtractFormatStringArgs;
 _CallFunction CallFunction;
+_CaptureLambdaVars CaptureLambdaVars;
+_UncaptureLambdaVars UncaptureLambdaVars;
 _InventoryRefCreate InventoryRefCreate;
 _InventoryRefGetForID InventoryRefGetForID;
 

--- a/internal/patches_game.h
+++ b/internal/patches_game.h
@@ -236,6 +236,7 @@ __declspec(naked) bool WheelTeammateHook()
 }
 
 Script *s_messageBoxScript = NULL;
+LambdaVariableContext s_messageBoxScriptVariableContext(nullptr);
 
 __declspec(naked) float MaxMessageWidthHook()
 {

--- a/jip_nvse.cpp
+++ b/jip_nvse.cpp
@@ -1395,7 +1395,10 @@ bool NVSEPlugin_Load(const NVSEInterface *nvse)
 	InventoryRefCreate = (_InventoryRefCreate)nvseData->GetFunc(NVSEDataInterface::kNVSEData_InventoryReferenceCreateEntry);
 	InventoryRefGetForID = (_InventoryRefGetForID)nvseData->GetFunc(NVSEDataInterface::kNVSEData_InventoryReferenceGetForRefID);
 	g_numPreloadMods = (UInt8*)nvseData->GetData(NVSEDataInterface::kNVSEData_NumPreloadMods);
-
+	CaptureLambdaVars = (_CaptureLambdaVars)nvseData->GetFunc(NVSEDataInterface::kNVSEData_LambdaSaveVariableList);
+	UncaptureLambdaVars = (_UncaptureLambdaVars)nvseData->GetFunc(NVSEDataInterface::kNVSEData_LambdaUnsaveVariableList);
+	
+	
 	return true;
 }
 

--- a/nvse/PluginAPI.h
+++ b/nvse/PluginAPI.h
@@ -546,6 +546,12 @@ struct NVSEDataInterface
 		kNVSEData_StringVarMapDeleteBySelf,
 		kNVSEData_LambdaDeleteAllForScript,
 		kNVSEData_InventoryReferenceCreateEntry,
+		kNVSEData_LambdaSaveVariableList,
+		kNVSEData_LambdaUnsaveVariableList,
+
+		kNVSEData_IsScriptLambda,
+		kNVSEData_HasScriptCommand,
+		kNVSEData_DecompileScript,
 		kNVSEData_FuncMax,
 	};
 	void * (* GetFunc)(UInt32 funcID);


### PR DESCRIPTION
…pCallback

I did not know of a way to add the functionality to the rest of the event handlers. 

In practice I have a struct with a constructor and destructor that gets stored with the Script* pointer. The constructor calls CaptureLambdaVariables and the destructor calls UncaptureLambdaVariables. So when a callback gets removed from a data collection (along with the script), it'll uncapture the variable list for the potential lambda as the destructor gets called.