### PR TITLE
Enhance RefMapArray(Get/Set)Value

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,17 @@
+
+*.tlog
+*.pdb
+*.obj
+*.dll
+*.exp
+*.iobj
+*.lib
+*.recipe
+*.res
+*.log
+*.ipch
+.vs/jip_nvse/v16/.suo
+*.db
+*.db-shm
+*.db-wal
+*.opendb

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@
 *.db-shm
 *.db-wal
 *.opendb
+.vs/jip_nvse/v17/.suo
+*.ipdb

--- a/functions_jip/jip_fn_ref_map.h
+++ b/functions_jip/jip_fn_ref_map.h
@@ -308,7 +308,7 @@ bool Cmd_RefMapArraySetValue_Execute(COMMAND_ARGS)
 		if (eval.NumArgs() >= 3)
 			form = eval.GetNthArg(2)->GetTESForm();
 
-		if (newVal.IsValid())
+		if (newVal.IsValid() && newVal.GetType() != NVSEArrayVarInterface::kType_Array)
 		{
 			REF_MAP_CS
 			if (AuxVariableValue *value = RefMapAddValue(form, thisObj, scriptObj, varName))

--- a/functions_jip/jip_fn_ref_map.h
+++ b/functions_jip/jip_fn_ref_map.h
@@ -13,7 +13,7 @@ DEFINE_COMMAND_ALT_PLUGIN(RefMapArrayGetAll, RefMapGetAll, 0, 1, kParams_OneInt)
 DEFINE_COMMAND_ALT_PLUGIN(RefMapArraySetFloat, RefMapSetFlt, 0, 3, kParams_OneString_OneDouble_OneOptionalForm);
 DEFINE_COMMAND_ALT_PLUGIN(RefMapArraySetRef, RefMapSetRef, 0, 3, kParams_OneString_OneForm_OneOptionalForm);
 DEFINE_COMMAND_ALT_PLUGIN(RefMapArraySetString, RefMapSetStr, 0, 3, kParams_TwoStrings_OneOptionalForm);
-DEFINE_COMMAND_ALT_PLUGIN_EXP(RefMapArraySetValue, RefMapSetVal, false, kNVSEParams_OneString_OneArray_OneOptionalForm);
+DEFINE_COMMAND_ALT_PLUGIN_EXP(RefMapArraySetValue, RefMapSetVal, false, kNVSEParams_OneString_OneElem_OneOptionalForm);
 DEFINE_COMMAND_ALT_PLUGIN(RefMapArrayErase, RefMapErase, 0, 2, kParams_OneString_OneOptionalForm);
 DEFINE_COMMAND_ALT_PLUGIN(RefMapArrayValidate, RefMapValidate, 0, 1, kParams_OneString);
 DEFINE_COMMAND_ALT_PLUGIN(RefMapArrayDestroy, RefMapDestroy, 0, 1, kParams_OneString);

--- a/functions_ln/ln_fn_miscellaneous.h
+++ b/functions_ln/ln_fn_miscellaneous.h
@@ -505,7 +505,7 @@ bool Cmd_GetZoneFlag_Execute(COMMAND_ARGS)
 	BGSEncounterZone *encZone;
 	UInt32 flag;
 	if (ExtractArgsEx(EXTRACT_ARGS_EX, &encZone, &flag) && IS_ID(encZone, BGSEncounterZone))
-		*result = (encZone->flags & flag) ? 1 : 0;
+		*result = (encZone->zoneFlags & flag) ? 1 : 0;
 	else *result = 0;
 	return true;
 }

--- a/jip_nvse.cpp
+++ b/jip_nvse.cpp
@@ -4,6 +4,7 @@
 #include "internal/xinput.h"
 #include "internal/jip_core.h"
 #include "nvse/ParamInfos.h"
+#include "nvse/NVSEParamInfos.h"
 #include "internal/hooks.h"
 #include "internal/patches_cmd.h"
 #include "internal/patches_game.h"
@@ -832,7 +833,7 @@ bool NVSEPlugin_Load(const NVSEInterface *nvse)
 	/*2761*/REG_CMD(IsInCombatWith);
 	/*2762*/REG_CMD_STR(RefToPosStr);
 	/*2763*/REG_CMD(MoveToPosStr);
-	/*2764*/REG_CMD_ARR(RefMapArrayGetValue);
+	/*2764*/REG_CMD_AMB(RefMapArrayGetValue);
 	/*2765*/REG_CMD(RefMapArraySetValue);
 	/*2766*/REG_CMD_ARR(GetAllItems);
 	/*2767*/REG_CMD_ARR(GetAllItemRefs);
@@ -1371,7 +1372,7 @@ bool NVSEPlugin_Load(const NVSEInterface *nvse)
 		return true;
 	}
 
-	//nvse->InitExpressionEvaluatorUtils(&s_expEvalUtils);
+	nvse->InitExpressionEvaluatorUtils(&s_expEvalUtils);
 
 	PluginHandle pluginHandle = nvse->GetPluginHandle();
 	NVSESerializationInterface *serialization = (NVSESerializationInterface*)nvse->QueryInterface(kInterface_Serialization);

--- a/jip_nvse.vcxproj
+++ b/jip_nvse.vcxproj
@@ -191,6 +191,7 @@
     <ClInclude Include="internal\utility.h" />
     <ClInclude Include="internal\version.h" />
     <ClInclude Include="internal\xinput.h" />
+    <ClInclude Include="NVSEParamInfos.h" />
     <ClInclude Include="nvse\CommandTable.h" />
     <ClInclude Include="nvse\GameAPI.h" />
     <ClInclude Include="nvse\GameBSExtraData.h" />

--- a/jip_nvse.vcxproj.filters
+++ b/jip_nvse.vcxproj.filters
@@ -388,6 +388,9 @@
     <ClInclude Include="internal\Ni_types.h">
       <Filter>internal</Filter>
     </ClInclude>
+    <ClInclude Include="NVSEParamInfos.h">
+      <Filter>nvse</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include="exports.def" />

--- a/nvse/CommandTable.h
+++ b/nvse/CommandTable.h
@@ -139,11 +139,11 @@ struct ParamInfo
 #define DEFINE_COMMAND_ALT_PLUGIN(name, altName, refRequired, numParams, paramInfo) \
 	DEFINE_CMD_FULL(name, altName, refRequired, numParams, paramInfo, NULL)
 
-#define DEFINE_COMMAND_PLUGIN_EXP(name, refRequired, numParams, paramInfo) \
-	DEFINE_CMD_FULL(name, , refRequired, numParams, paramInfo, Cmd_Expression_Plugin_Parse)
+#define DEFINE_COMMAND_PLUGIN_EXP(name, refRequired, paramInfo) \
+	DEFINE_CMD_FULL(name, , refRequired, (sizeof(paramInfo) / sizeof(ParamInfo)), reinterpret_cast<const ParamInfo*>(paramInfo), Cmd_Expression_Plugin_Parse)
 
-#define DEFINE_COMMAND_ALT_PLUGIN_EXP(name, altName, refRequired, numParams, paramInfo) \
-	DEFINE_CMD_FULL(name, altName, refRequired, numParams, paramInfo, Cmd_Expression_Plugin_Parse)
+#define DEFINE_COMMAND_ALT_PLUGIN_EXP(name, altName, refRequired, paramInfo) \
+	DEFINE_CMD_FULL(name, altName, refRequired, (sizeof(paramInfo) / sizeof(ParamInfo)), reinterpret_cast<const ParamInfo*>(paramInfo), Cmd_Expression_Plugin_Parse)
 
 // for commands which can be used as conditionals
 #define DEFINE_CMD_ALT_COND_ANY(name, altName, refRequired, numParams, paramInfo, parser) \
@@ -203,7 +203,7 @@ struct CommandInfo
 	const char	* helpText;		// 0C
 	UInt16		needsParent;	// 10
 	UInt16		numParams;		// 12
-	ParamInfo	* params;		// 14
+	const ParamInfo	* params;	// 14
 
 	// handlers
 	Cmd_Execute	execute;		// 18

--- a/nvse/NVSEParamInfos.h
+++ b/nvse/NVSEParamInfos.h
@@ -54,6 +54,12 @@ static constexpr NVSEParamInfo kNVSEParams_OneString_OneArray_OneOptionalForm[3]
 	{	"array",	kNVSEParamType_Array,	0	},
 	{	"form",	kNVSEParamType_Form,	1	},
 };
+static constexpr NVSEParamInfo kNVSEParams_OneString_OneElem_OneOptionalForm[3] =
+{
+	{	"string",	kNVSEParamType_String,	0	},
+	{	"elem",	kNVSEParamType_BasicType,	0	},
+	{	"form",	kNVSEParamType_Form,	1	},
+};
 static constexpr NVSEParamInfo kNVSEParams_OneString_OneStringOrNumber[2] =
 {
 	{	"string",	kNVSEParamType_String,	0	},

--- a/nvse/NVSEParamInfos.h
+++ b/nvse/NVSEParamInfos.h
@@ -1,0 +1,298 @@
+#pragma once
+
+#include "nvse\PluginAPI.h"
+
+//additional type safety
+struct NVSEParamInfo
+{
+	const char* typeStr;
+	NVSEParamTypes	typeID;		// ParamType
+	UInt32	isOptional;	// do other bits do things?
+};
+
+
+// Declare Params with "static", so they are only built once (so this file can be included multiple times).
+
+
+static constexpr NVSEParamInfo kNVSEParams_OneArray[1] =
+{
+	{	"array",	kNVSEParamType_Array,	0	},
+};
+static constexpr NVSEParamInfo kNVSEParams_OneArray_OneForm[2] =
+{
+	{	"array",	kNVSEParamType_Array,	0	},
+	{	"form",	kNVSEParamType_Form,	0	},
+};
+
+static constexpr NVSEParamInfo kNVSEParams_OneString[1] =
+{
+	{	"string",	kNVSEParamType_String,	0	},
+};
+static constexpr NVSEParamInfo kNVSEParams_OneOptionalString[1] =
+{
+	{	"string",	kNVSEParamType_String,	1	},
+};
+static constexpr NVSEParamInfo kNVSEParams_OneString_OneNumber[2] =
+{
+	{	"string",	kNVSEParamType_String,	0	},
+	{	"num",	kNVSEParamType_Number,	0	},
+};
+static constexpr NVSEParamInfo kNVSEParams_OneString_OneOptionalForm[2] =
+{
+	{	"string",	kNVSEParamType_String,	0	},
+	{	"form",	kNVSEParamType_Form,	1	},
+};
+static constexpr NVSEParamInfo kNVSEParams_OneString_OneNumber_OneOptionalForm[3] =
+{
+	{	"string",	kNVSEParamType_String,	0	},
+	{	"number",	kNVSEParamType_Number,	0	},
+	{	"form",	kNVSEParamType_Form,	1	},
+};
+static constexpr NVSEParamInfo kNVSEParams_OneString_OneArray_OneOptionalForm[3] =
+{
+	{	"string",	kNVSEParamType_String,	0	},
+	{	"array",	kNVSEParamType_Array,	0	},
+	{	"form",	kNVSEParamType_Form,	1	},
+};
+static constexpr NVSEParamInfo kNVSEParams_OneString_OneStringOrNumber[2] =
+{
+	{	"string",	kNVSEParamType_String,	0	},
+	{	"string or num",	kNVSEParamType_StringOrNumber,	0	},
+};
+
+static constexpr NVSEParamInfo kNVSEParams_OneBasicType_OneBoolean[2] =
+{
+	{	"string",	kNVSEParamType_BasicType,	0	},
+	{	"bool",	kNVSEParamType_Boolean,	0	},
+};
+static constexpr NVSEParamInfo kNVSEParams_OneBasicType_OneOptionalBoolean[2] =
+{
+	{	"string",	kNVSEParamType_BasicType,	0	},
+	{	"bool",	kNVSEParamType_Boolean,	1	},
+};
+
+static constexpr NVSEParamInfo kNVSEParams_OneNumber_OneOptionalString[2] =
+{
+	{	"num",	kNVSEParamType_Number,	0	},
+	{	"string",	kNVSEParamType_String,	1	},
+};
+
+static constexpr NVSEParamInfo kNVSEParams_OneOptionalString_TwoOptionalNumbers[3] =
+{
+	{	"string",	kNVSEParamType_String,	1	},
+	{	"num",	kNVSEParamType_Number,	1	},
+	{	"num",	kNVSEParamType_Number,	1	},
+};
+
+static constexpr NVSEParamInfo kNVSEParams_OneOptionalStringOrNumber[1] =
+{
+	{	"string or number",	kNVSEParamType_StringOrNumber,	1	},
+};
+static constexpr NVSEParamInfo kNVSEParams_OneOptionalBoolean[1] =
+{
+	{	"bool",	kNVSEParamType_Boolean,	1	},
+};
+
+static constexpr NVSEParamInfo kNVSEParams_OneForm_OneArray_OneOptionalIndex[3] =
+{
+	{	"form",	kNVSEParamType_Form,	0	},
+	{	"array",	kNVSEParamType_Array,	0	},
+	{	"index",	kNVSEParamType_Number,1	},
+};
+
+static constexpr NVSEParamInfo kNVSEParams_OneArray_OneString_OneArray[3] =
+{
+	{	"array",	kNVSEParamType_Array,	0	},
+	{	"string",	kNVSEParamType_String,0	},
+	{	"array",	kNVSEParamType_Array,	0	},
+};
+static constexpr NVSEParamInfo kNVSEParams_OneArray_OneString_OneDouble[3] =
+{
+	{	"array",	kNVSEParamType_Array,	0	},
+	{	"string",	kNVSEParamType_String,0	},
+	{	"float",	kNVSEParamType_Number,0	},
+};
+
+static constexpr NVSEParamInfo kNVSEParams_OneForm_OneArray[2] =
+{
+	{	"form",	kNVSEParamType_Form,	0	},
+	{	"array",	kNVSEParamType_Array,	0	},
+};
+
+
+static constexpr NVSEParamInfo kNVSEParams_OneString_OneOptionalString_OneOptionalInt[3] =
+{
+	{	"string",	kNVSEParamType_String,0	},
+	{	"string",	kNVSEParamType_String,1	},
+	{	"int",	kNVSEParamType_Number,1	},
+};
+static constexpr NVSEParamInfo kNVSEParams_OneString_OneOptionalString_TwoOptionalInts[4] =
+{
+	{	"string",	kNVSEParamType_String,0	},
+	{	"string",	kNVSEParamType_String,1	},
+	{	"int",	kNVSEParamType_Number,1	},
+	{	"int",	kNVSEParamType_Number,1	},
+};
+static constexpr NVSEParamInfo kNVSEParams_OneString_OneOptionalString_OneOptionalInt_OneOptionalBool[4] =
+{
+	{	"string",	kNVSEParamType_String,0	},
+	{	"string",	kNVSEParamType_String,1	},
+	{	"int",	kNVSEParamType_Number,1	},
+	{	"bool",	kNVSEParamType_Boolean,1	},
+};
+
+static constexpr NVSEParamInfo kNVSEParams_OneElem_OneString_OneOptionalString_OneOptionalInt[4] =
+{
+	{	"elem",	kNVSEParamType_BasicType,0	},
+	{	"string",	kNVSEParamType_String,0	},
+	{	"string",	kNVSEParamType_String,1	},
+	{	"int",	kNVSEParamType_Number,1	},
+};
+static constexpr NVSEParamInfo kNVSEParams_OneElem_OneString_OneOptionalString_OneOptionalInt_TwoOptionalBools[6] =
+{
+	{	"elem",	kNVSEParamType_BasicType,0	},
+	{	"string",	kNVSEParamType_String,0	},
+	{	"string",	kNVSEParamType_String,1	},
+	{	"int",	kNVSEParamType_Number,1	},
+	{	"bool",	kNVSEParamType_Boolean,1	},
+	{	"bool",	kNVSEParamType_Boolean,1	},
+};
+
+static constexpr NVSEParamInfo kNVSEParams_OneString_OneElem_TwoOptionalStrings[4] =
+{
+	{	"string",	kNVSEParamType_String,0	},
+	{	"elem",	kNVSEParamType_BasicType,0	},
+	{	"string",	kNVSEParamType_String,1	},
+	{	"string",	kNVSEParamType_String,1	},
+};
+static constexpr NVSEParamInfo kNVSEParams_OneString_OneFloatOrString_TwoOptionalStrings[4] =
+{
+	{	"string",	kNVSEParamType_String,0	},
+	{	"float or string",	kNVSEParamType_StringOrNumber,0	},
+	{	"string",	kNVSEParamType_String,1	},
+	{	"string",	kNVSEParamType_String,1	},
+};
+static constexpr NVSEParamInfo kNVSEParams_OneString_OneFloatOrString_TwoOptionalStrings_TwoOptionalBools[6] =
+{
+	{	"string",	kNVSEParamType_String,0	},
+	{	"float or string",	kNVSEParamType_StringOrNumber,0	},
+	{	"string",	kNVSEParamType_String,1	},
+	{	"string",	kNVSEParamType_String,1	},
+	{	"bool",	kNVSEParamType_Boolean,1	},
+	{	"bool",	kNVSEParamType_Boolean,1	},
+};
+static constexpr NVSEParamInfo kNVSEParams_OneString_OneFloat_TwoOptionalStrings[4] =
+{
+	{	"string",	kNVSEParamType_String,0	},
+	{	"float",	kNVSEParamType_Number,0	},
+	{	"string",	kNVSEParamType_String,1	},
+	{	"string",	kNVSEParamType_String,1	},
+};
+static constexpr NVSEParamInfo kNVSEParams_OneString_OneFloat_TwoOptionalStrings_TwoOptionalBools[6] =
+{
+	{	"string",	kNVSEParamType_String,0	},
+	{	"float",	kNVSEParamType_Number,0	},
+	{	"string",	kNVSEParamType_String,1	},
+	{	"string",	kNVSEParamType_String,1	},
+	{	"bool",	kNVSEParamType_Boolean,1	},
+	{	"bool",	kNVSEParamType_Boolean,1	},
+};
+static constexpr NVSEParamInfo kNVSEParams_OneString_OneOptionalString[2] =
+{
+	{	"string",	kNVSEParamType_String,0	},
+	{	"string",	kNVSEParamType_String,1	},
+};
+static constexpr NVSEParamInfo kNVSEParams_OneString_OneOptionalString_OneOptionalBool[3] =
+{
+	{	"string",	kNVSEParamType_String,0	},
+	{	"string",	kNVSEParamType_String,1	},
+	{	"bool",	kNVSEParamType_Boolean,1	},
+};
+static constexpr NVSEParamInfo kNVSEParams_OneString_TwoOptionalStrings[3] =
+{
+	{	"string",	kNVSEParamType_String,0	},
+	{	"string",	kNVSEParamType_String,1	},
+	{	"string",	kNVSEParamType_String,1	},
+};
+static constexpr NVSEParamInfo kNVSEParams_OneString_TwoOptionalStrings_OneOptionalBool[4] =
+{
+	{	"string",	kNVSEParamType_String,0	},
+	{	"string",	kNVSEParamType_String,1	},
+	{	"string",	kNVSEParamType_String,1	},
+	{	"bool",	kNVSEParamType_Boolean,1	},
+};
+static constexpr NVSEParamInfo kNVSEParams_OneString_OneOptionalString_OneOptionalFloat[3] =
+{
+	{	"string",	kNVSEParamType_String,0	},
+	{	"string",	kNVSEParamType_String,1	},
+	{	"float",	kNVSEParamType_Number,1	},
+};
+static constexpr NVSEParamInfo kNVSEParams_OneString_OneOptionalString_OneOptionalFloat_OneOptionalBool[4] =
+{
+	{	"string",	kNVSEParamType_String,0	},
+	{	"string",	kNVSEParamType_String,1	},
+	{	"float",	kNVSEParamType_Number,1	},
+	{	"bool",	kNVSEParamType_Boolean,1	},
+};
+static constexpr NVSEParamInfo kNVSEParams_OneString_OneOptionalString_OneOptionalFloat_OneOptionalString[4] =
+{
+	{	"string",	kNVSEParamType_String,0	},
+	{	"string",	kNVSEParamType_String,1	},
+	{	"float",	kNVSEParamType_Number,1	},
+	{	"string",	kNVSEParamType_String,1	},
+};
+static constexpr NVSEParamInfo kNVSEParams_OneString_OneOptionalString_OneOptionalFloat_OneOptionalString_TwoOptionalBools[6] =
+{
+	{	"string",	kNVSEParamType_String,0	},
+	{	"string",	kNVSEParamType_String,1	},
+	{	"float",	kNVSEParamType_Number,1	},
+	{	"string",	kNVSEParamType_String,1	},
+	{	"bool",	kNVSEParamType_Boolean,1	},
+	{	"bool",	kNVSEParamType_Boolean,1	},
+
+};
+static constexpr NVSEParamInfo kNVSEParams_OneString_ThreeOptionalStrings[4] =
+{
+	{	"string",	kNVSEParamType_String,0	},
+	{	"string",	kNVSEParamType_String,1	},
+	{	"string",	kNVSEParamType_String,1	},
+	{	"string",	kNVSEParamType_String,1	},
+};
+static constexpr NVSEParamInfo kNVSEParams_OneString_ThreeOptionalStrings_TwoOptionalBools[6] =
+{
+	{	"string",	kNVSEParamType_String,0	},
+	{	"string",	kNVSEParamType_String,1	},
+	{	"string",	kNVSEParamType_String,1	},
+	{	"string",	kNVSEParamType_String,1	},
+	{	"bool",	kNVSEParamType_Boolean,1	},
+	{	"bool",	kNVSEParamType_Boolean,1	},
+};
+static constexpr NVSEParamInfo kNVSEParams_TwoStrings_TwoOptionalStrings[4] =
+{
+	{	"string",	kNVSEParamType_String,0	},
+	{	"string",	kNVSEParamType_String,0	},
+	{	"string",	kNVSEParamType_String,1	},
+	{	"string",	kNVSEParamType_String,1	},
+};
+static constexpr NVSEParamInfo kNVSEParams_TwoStrings_TwoOptionalStrings_TwoOptionalBools[6] =
+{
+	{	"string",	kNVSEParamType_String,0	},
+	{	"string",	kNVSEParamType_String,0	},
+	{	"string",	kNVSEParamType_String,1	},
+	{	"string",	kNVSEParamType_String,1	},
+	{	"bool",	kNVSEParamType_Boolean,1	},
+	{	"bool",	kNVSEParamType_Boolean,1	},
+};
+
+static constexpr NVSEParamInfo kNVSEParams_TwoNums_OneArray_OneStr_ThreeForms[7] =
+{
+	{	"num",	kNVSEParamType_Number,	0	},
+	{	"num",	kNVSEParamType_Number,	0	},
+
+	{	"array",	kNVSEParamType_Array,	0},
+	{	"string",	kNVSEParamType_String,	0	},
+
+	{	"form",	kNVSEParamType_Form,	0	},
+	{	"form",	kNVSEParamType_Form,	0	},
+	{	"form",	kNVSEParamType_Form,	0	},
+};


### PR DESCRIPTION
Instead of taking/giving a single-element array, they now take/give a value of any type, similar to how it's done for NVSE functions like `Ar_List`. This should make them more convenient to use.

Below is a unit test to verify that these functions are working. You could remove the script name line and paste this into a file in `data\nvse\unit_tests`, so that if you have the "run unit tests" option enabled in xNVSE's ini, this test will be automatically executed whenever you launch the game, to verify it doesn't break in the future. (That's with xNVSE 6.2.8)

```scn TestRefMapArrayGetSetValue

begin Function { }

	array_var aBoxed

	float fExpected = 1.5
	player.RefMapArraySetValue "test" fExpected 
	aBoxed = &(player.RefMapArrayGetValue "test")
	assert (*aBoxed == fExpected )
	assert ((player.RefMapArrayGetValue "test") == fExpected)
	float fVal = player.RefMapArrayGetValue "test"
	assert (fVal == fExpected)

	ref rExpected = SunnyREF
	player.RefMapArraySetValue "test" rExpected 
	aBoxed = &(player.RefMapArrayGetValue "test")
	assert (*aBoxed == rExpected )
	assert ((player.RefMapArrayGetValue "test") == rExpected )
	ref rVal = player.RefMapArrayGetValue "test"
	assert (rVal == rExpected)

	string_var sExpected = "expect"
	player.RefMapArraySetValue "test" sExpected 
	aBoxed = &(player.RefMapArrayGetValue "test")
	assert (*aBoxed == sExpected )
	assert ((player.RefMapArrayGetValue "test") == sExpected )
	string_var sVal = player.RefMapArrayGetValue "test"
	assert (sVal == sExpected)

/* Arrays are NOT supported

	array_var aExpected = ar_list 1, 2
	player.RefMapArraySetValue "test" aExpected 
	aBoxed = &(player.RefMapArrayGetValue "test")
	printvar aBoxed  ; PRINTS GARBAGE!
	assert (*aBoxed == aExpected )
	;assert ((player.RefMapArrayGetValue "test") == aExpected )
	array_var aVal = player.RefMapArrayGetValue "test"
	printvar aVal
	assert (aVal == aExpected )
*/

	print "Finished running JIP RefMapArray(Get/Set)Value tests." 

end
```