### PR TITLE
Compatibility with {fmt} library macros

### DIFF
--- a/functions_jip/jip_fn_actor.h
+++ b/functions_jip/jip_fn_actor.h
@@ -2336,7 +2336,7 @@ bool Cmd_ToggleTeammateKillable_Execute(COMMAND_ARGS)
 		bool state = (actor->jipActorFlags2 & kHookActorFlag2_TeammateKillable) != 0;
 		*result = state;
 		UInt32 doSet;
-		if (NUM_ARGS && ExtractArgsEx(EXTRACT_ARGS_EX, &doSet) && (!doSet == state))
+		if (NUM_ARGS_JIP && ExtractArgsEx(EXTRACT_ARGS_EX, &doSet) && (!doSet == state))
 			actor->jipActorFlags2 ^= kHookActorFlag2_TeammateKillable;
 	}
 	else *result = 0;
@@ -2351,7 +2351,7 @@ bool Cmd_ToggleNoGunWobble_Execute(COMMAND_ARGS)
 		bool state = (actor->jipActorFlags2 & kHookActorFlag2_NoGunWobble) != 0;
 		*result = state;
 		UInt32 doSet;
-		if (NUM_ARGS && ExtractArgsEx(EXTRACT_ARGS_EX, &doSet) && (!doSet == state))
+		if (NUM_ARGS_JIP && ExtractArgsEx(EXTRACT_ARGS_EX, &doSet) && (!doSet == state))
 			actor->jipActorFlags2 ^= kHookActorFlag2_NoGunWobble;
 	}
 	else *result = 0;

--- a/functions_jip/jip_fn_input.h
+++ b/functions_jip/jip_fn_input.h
@@ -91,7 +91,7 @@ bool Cmd_ToggleVanityWheel_Execute(COMMAND_ARGS)
 {
 	*result = s_vanityEnabled;
 	UInt32 toggle;
-	if (NUM_ARGS && ExtractArgsEx(EXTRACT_ARGS_EX, &toggle) && (s_vanityEnabled == !toggle))
+	if (NUM_ARGS_JIP && ExtractArgsEx(EXTRACT_ARGS_EX, &toggle) && (s_vanityEnabled == !toggle))
 	{
 		s_vanityEnabled = !s_vanityEnabled;
 		SafeWrite8(0x945A29, toggle ? 0x8B : 0x89);
@@ -103,7 +103,7 @@ bool Cmd_ToggleMouseMovement_Execute(COMMAND_ARGS)
 {
 	*result = int(s_mouseMovementState & 3);
 	UInt32 toggle;
-	if (NUM_ARGS && ExtractArgsEx(EXTRACT_ARGS_EX, &toggle))
+	if (NUM_ARGS_JIP && ExtractArgsEx(EXTRACT_ARGS_EX, &toggle))
 		s_mouseMovementState = toggle | 4;
 	return true;
 }

--- a/functions_jip/jip_fn_miscellaneous.h
+++ b/functions_jip/jip_fn_miscellaneous.h
@@ -934,7 +934,7 @@ bool Cmd_FreezeTime_Execute(COMMAND_ARGS)
 {
 	*result = g_OSGlobals->freezeTime;
 	UInt32 toggle;
-	if (NUM_ARGS && ExtractArgsEx(EXTRACT_ARGS_EX, &toggle) && (g_OSGlobals->freezeTime == !toggle))
+	if (NUM_ARGS_JIP && ExtractArgsEx(EXTRACT_ARGS_EX, &toggle) && (g_OSGlobals->freezeTime == !toggle))
 		g_OSGlobals->freezeTime = toggle != 0;
 	return true;
 }
@@ -976,7 +976,7 @@ bool Cmd_ToggleImmortalMode_Execute(COMMAND_ARGS)
 {
 	*result = s_playerMinHPMode;
 	UInt32 toggle;
-	if (NUM_ARGS && ExtractArgsEx(EXTRACT_ARGS_EX, &toggle))
+	if (NUM_ARGS_JIP && ExtractArgsEx(EXTRACT_ARGS_EX, &toggle))
 	{
 		s_playerMinHPMode = toggle;
 		HOOK_SET(PlayerMinHealth, toggle == 1);
@@ -991,7 +991,7 @@ bool Cmd_ToggleCameraCollision_Execute(COMMAND_ARGS)
 	static bool cameraCollision = true;
 	*result = cameraCollision;
 	UInt32 toggle;
-	if (NUM_ARGS && ExtractArgsEx(EXTRACT_ARGS_EX, &toggle) && (!toggle == cameraCollision))
+	if (NUM_ARGS_JIP && ExtractArgsEx(EXTRACT_ARGS_EX, &toggle) && (!toggle == cameraCollision))
 	{
 		cameraCollision = !cameraCollision;
 		SafeWrite8(0x94A34E, toggle ? 0x74 : 0xEB);
@@ -1107,7 +1107,7 @@ bool Cmd_ToggleHitEffects_Execute(COMMAND_ARGS)
 {
 	*result = !s_disableHitEffects;
 	UInt32 toggle;
-	if (NUM_ARGS && ExtractArgsEx(EXTRACT_ARGS_EX, &toggle))
+	if (NUM_ARGS_JIP && ExtractArgsEx(EXTRACT_ARGS_EX, &toggle))
 	{
 		if (toggle) s_disableHitEffects &= 2;
 		else s_disableHitEffects |= 1;
@@ -1119,7 +1119,7 @@ bool Cmd_ToggleNoMovementCombat_Execute(COMMAND_ARGS)
 {
 	*result = s_noMovementCombat;
 	UInt32 toggle;
-	if (NUM_ARGS && ExtractArgsEx(EXTRACT_ARGS_EX, &toggle))
+	if (NUM_ARGS_JIP && ExtractArgsEx(EXTRACT_ARGS_EX, &toggle))
 		s_noMovementCombat = toggle != 0;
 	return true;
 }
@@ -1303,7 +1303,7 @@ bool Cmd_SetArmorConditionPenalty_Execute(COMMAND_ARGS)
 {
 	*result = s_condDRDTPenalty;
 	float value;
-	if (NUM_ARGS && ExtractArgsEx(EXTRACT_ARGS_EX, &value))
+	if (NUM_ARGS_JIP && ExtractArgsEx(EXTRACT_ARGS_EX, &value))
 		s_condDRDTPenalty = value;
 	return true;
 }

--- a/functions_jip/jip_fn_miscellaneous.h
+++ b/functions_jip/jip_fn_miscellaneous.h
@@ -956,7 +956,7 @@ bool Cmd_SetConditionDamagePenalty_Execute(COMMAND_ARGS)
 bool Cmd_ToggleBipedSlotVisibility_Execute(COMMAND_ARGS)
 {
 	*result = 0;
-	UInt8 numArgs = NUM_ARGS;
+	UInt8 numArgs = NUM_ARGS_JIP;
 	UInt32 slotID, toggle;
 	if (ExtractArgsEx(EXTRACT_ARGS_EX, &slotID, &toggle) && (slotID <= 19))
 	{

--- a/functions_jip/jip_fn_ui.h
+++ b/functions_jip/jip_fn_ui.h
@@ -1696,7 +1696,7 @@ bool Cmd_SetUIFloatGradual_Execute(COMMAND_ARGS)
 	char tilePath[0x100];
 	float startVal, endVal, timer;
 	UInt32 changeMode = 0;
-	UInt8 numArgs = NUM_ARGS;
+	UInt8 numArgs = NUM_ARGS_JIP;
 	if (ExtractArgsEx(EXTRACT_ARGS_EX, &tilePath, &startVal, &endVal, &timer, &changeMode))
 	{
 		Tile::Value *tileVal = NULL;

--- a/functions_jip/jip_fn_ui.h
+++ b/functions_jip/jip_fn_ui.h
@@ -1259,7 +1259,7 @@ bool Cmd_ToggleCraftingMessages_Execute(COMMAND_ARGS)
 {
 	*result = s_craftingMessages;
 	UInt32 toggle;
-	if (NUM_ARGS && ExtractArgsEx(EXTRACT_ARGS_EX, &toggle) && (s_craftingMessages == !toggle))
+	if (NUM_ARGS_JIP && ExtractArgsEx(EXTRACT_ARGS_EX, &toggle) && (s_craftingMessages == !toggle))
 	{
 		s_craftingMessages = !s_craftingMessages;
 		SafeWriteBuf(0x728933, s_craftingMessages ? "\x8D\x4D\xCC\xE8\x75" : "\xE9\xC4\x00\x00\x00", 5);
@@ -1528,7 +1528,7 @@ bool Cmd_TogglePipBoyLight_Execute(COMMAND_ARGS)
 	SpellItem *pipBoyLight = GameGlobals::PipBoyLight();
 	UInt32 turnON, currState = ThisCall<bool>(0x822B90, &g_thePlayer->magicTarget, &pipBoyLight->magicItem, 1);
 	*result = (int)currState;
-	if (NUM_ARGS && ExtractArgsEx(EXTRACT_ARGS_EX, &turnON) && (turnON != currState))
+	if (NUM_ARGS_JIP && ExtractArgsEx(EXTRACT_ARGS_EX, &turnON) && (turnON != currState))
 		TogglePipBoyLight(g_thePlayer, pipBoyLight, turnON);
 	return true;
 }
@@ -1627,7 +1627,7 @@ bool Cmd_ToggleHUDCursor_Execute(COMMAND_ARGS)
 {
 	*result = s_HUDCursorMode;
 	UInt32 toggle;
-	if (NUM_ARGS && ExtractArgsEx(EXTRACT_ARGS_EX, &toggle) && (g_interfaceManager->currentMode == 1) && !s_controllerReady && (s_HUDCursorMode == !toggle))
+	if (NUM_ARGS_JIP && ExtractArgsEx(EXTRACT_ARGS_EX, &toggle) && (g_interfaceManager->currentMode == 1) && !s_controllerReady && (s_HUDCursorMode == !toggle))
 	{
 		s_HUDCursorMode = !s_HUDCursorMode;
 		if (toggle)

--- a/functions_jip/jip_fn_utility.h
+++ b/functions_jip/jip_fn_utility.h
@@ -25,7 +25,7 @@ DEFINE_COMMAND_PLUGIN(GetSessionTime, 0, 0, NULL);
 bool Cmd_RefToString_Execute(COMMAND_ARGS)
 {
 	TESForm *form = NULL;
-	if (!NUM_ARGS)
+	if (!NUM_ARGS_JIP)
 		form = thisObj;
 	else if (ExtractArgsEx(EXTRACT_ARGS_EX, &form) && IS_REFERENCE(form))
 		form = ((TESObjectREFR*)form)->baseForm;
@@ -44,7 +44,7 @@ bool Cmd_StringToRef_Execute(COMMAND_ARGS)
 
 bool Cmd_GetMinOf_Execute(COMMAND_ARGS)
 {
-	UInt8 numArgs = NUM_ARGS;
+	UInt8 numArgs = NUM_ARGS_JIP;
 	double val1, val2, val3, val4, val5;
 	if (ExtractArgsEx(EXTRACT_ARGS_EX, &val1, &val2, &val3, &val4, &val5))
 	{
@@ -73,7 +73,7 @@ bool Cmd_GetMinOf_Execute(COMMAND_ARGS)
 
 bool Cmd_GetMaxOf_Execute(COMMAND_ARGS)
 {
-	UInt8 numArgs = NUM_ARGS;
+	UInt8 numArgs = NUM_ARGS_JIP;
 	double val1, val2, val3, val4, val5;
 	if (ExtractArgsEx(EXTRACT_ARGS_EX, &val1, &val2, &val3, &val4, &val5))
 	{

--- a/internal/jip_core.h
+++ b/internal/jip_core.h
@@ -928,7 +928,7 @@ void InitMemUsageDisplay(UInt32 callDelay);
 #define REG_CMD_AMB(name) RegisterTypedCommand(&kCommandInfo_##name, kRetnType_Ambiguous)
 
 #define REFR_RES *(UInt32*)result
-#define NUM_ARGS scriptData[*opcodeOffsetPtr]
+#define NUM_ARGS_JIP scriptData[*opcodeOffsetPtr]
 #define NUM_ARGS_EX (scriptData[*opcodeOffsetPtr - 2] ? scriptData[*opcodeOffsetPtr] : 0)
 
 DEFINE_COMMAND_PLUGIN(EmptyCommand, 0, 0, NULL);

--- a/nvse/GameExtraData.cpp
+++ b/nvse/GameExtraData.cpp
@@ -612,6 +612,7 @@ __declspec(naked) float __vectorcall ExtraContainerChanges::EntryData::GetHealth
 
 bool __fastcall GetEntryDataHasModHook(ContChangesEntry *entry, int EDX, UInt8 modType);
 
+#ifndef JIP_AS_LIBRARY
 __declspec(naked) float ExtraContainerChanges::EntryData::CalculateWeaponDamage(Actor *owner, float condition, TESForm *ammo) const
 {
 	static const double kSplitBeamMult = 1.3;
@@ -678,6 +679,7 @@ __declspec(naked) float ExtraContainerChanges::EntryData::CalculateWeaponDamage(
 		retn	0xC
 	}
 }
+#endif
 
 ContChangesEntry *ContChangesEntry::CreateCopy(ExtraDataList *xData)
 {

--- a/nvse/GameExtraData.cpp
+++ b/nvse/GameExtraData.cpp
@@ -610,9 +610,10 @@ __declspec(naked) float __vectorcall ExtraContainerChanges::EntryData::GetHealth
 	}
 }
 
+#ifndef JIP_AS_LIBRARY
 bool __fastcall GetEntryDataHasModHook(ContChangesEntry *entry, int EDX, UInt8 modType);
 
-#ifndef JIP_AS_LIBRARY
+
 __declspec(naked) float ExtraContainerChanges::EntryData::CalculateWeaponDamage(Actor *owner, float condition, TESForm *ammo) const
 {
 	static const double kSplitBeamMult = 1.3;

--- a/nvse/GameExtraData.h
+++ b/nvse/GameExtraData.h
@@ -347,7 +347,9 @@ public:
 		float __vectorcall GetWeaponModEffectValue(UInt32 effectType) const;
 		float __vectorcall GetBaseHealth() const;
 		float __vectorcall GetHealthPercent() const;
+#ifndef JIP_AS_LIBRARY
 		float CalculateWeaponDamage(Actor *owner, float condition, TESForm *ammo) const;
+#endif
 		EntryData *CreateCopy(ExtraDataList *xData);
 	};
 

--- a/nvse/GameObjects.cpp
+++ b/nvse/GameObjects.cpp
@@ -65,6 +65,7 @@ ScriptEventList *TESObjectREFR::GetEventList() const
 	return xScript ? xScript->eventList : NULL;
 }
 
+#ifndef JIP_AS_LIBRARY
 void __fastcall HidePointLights(NiNode *objNode);
 extern ModelLoader *g_modelLoader;
 
@@ -106,6 +107,7 @@ __declspec(naked) void TESObjectREFR::Update3D()
 		retn
 	}
 }
+#endif JIP_AS_LIBRARY
 
 TESObjectREFR *TESObjectREFR::Create(bool bTemp)
 {
@@ -1330,6 +1332,7 @@ bool Actor::IsItemEquipped(TESForm *item) const
 	return false;
 }
 
+#ifndef JIP_AS_LIBRARY
 bool __fastcall GetEntryDataHasModHook(ContChangesEntry *entry, int EDX, UInt8 modType);
 
 UInt8 Actor::EquippedWeaponHasMod(UInt32 modType) const
@@ -1348,6 +1351,7 @@ UInt8 Actor::EquippedWeaponHasMod(UInt32 modType) const
 		return 1;
 	return GetEntryDataHasModHook(weaponInfo, 0, modType) ? 2 : 0;
 }
+#endif
 
 bool Actor::IsSneaking() const
 {


### PR DESCRIPTION
fmt uses an ambiguous macro NUM_ARGS which JIP also has defined.

JIP's NUM_ARGS has been renamed to NUM_ARGS_JIP to resolve this conflict.