### PR TITLE
Fix Get/SetLockedOut functions

### DIFF
--- a/functions_ln/ln_fn_terminal.h
+++ b/functions_ln/ln_fn_terminal.h
@@ -108,6 +108,7 @@ bool Cmd_SetLockedOut_Execute(COMMAND_ARGS)
 			refr->extraDataList.AddExtra(xTerm);
 		}
 		xTerm->lockedOut = state;
+		refr->MarkModified(0x80000000);
 	}
 	else if IS_ID(refr->baseForm, TESObjectDOOR)
 	{
@@ -118,14 +119,18 @@ bool Cmd_SetLockedOut_Execute(COMMAND_ARGS)
 			if (xTeleport && xTeleport->data && xTeleport->data->linkedDoor)
 			{
 				xLock = GetExtraType(&xTeleport->data->linkedDoor->extraDataList, ExtraLock);
+				if (xLock && xLock->data)
+				{
+					xLock->data->unk0C = state;
+					xTeleport->data->linkedDoor->MarkModified(0x1000);
+					return true;
+				}
 			}
-			if (!xLock)
-			{
-				xLock = ExtraLock::Create();
-				refr->extraDataList.AddExtra(xLock);
-			}
+			xLock = ExtraLock::Create();
+			refr->extraDataList.AddExtra(xLock);
 		}
 		xLock->data->unk0C = state;
+		refr->MarkModified(0x1000);
 	}
 	else
 	{
@@ -136,6 +141,7 @@ bool Cmd_SetLockedOut_Execute(COMMAND_ARGS)
 			refr->extraDataList.AddExtra(xLock);
 		}
 		xLock->data->unk0C = state;
+		refr->MarkModified(0x1000);
 	}
 	return true;
 }


### PR DESCRIPTION
`SetLockedOut` was creating empty `ExtraTerminalState` data for Terminals, overriding the Hack Difficulty set on their base forms. Both `SetLockedOut` and `GetLockedOut` were only checking for and setting `ExtraLock` data on Doors without considering they might be inheriting it from their teleport doors. All changes made by `SetLockedOut` also needed to be marked for the game to handle them correctly on save/load.

I'm not 100% sure on the `0x80000000` flag for `ExtraTerminalState`, but it's used in some game code and it works so ¯\\_(ツ)\_/¯.